### PR TITLE
track modelのバリデーション修正

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -8,7 +8,7 @@ class Track < ApplicationRecord
               
   validates :name,            presence: true # 曲名
   
-  validates :length_hour,     presence: true, default: 0,
+  validates :length_hour,     presence: true,
     format: { with: /\A\d\z/,
               message: "半角数字で入力して下さい。"  }
               


### PR DESCRIPTION
:length_hourカラムの:default 0の指定があると登録時にバリデーションエラーがどうしても出てしまうので削りました。これで商品のデータベース登録は問題無く行えますが、なぜ:default 0があるとダメなのかわかりません。意図があっての記述だと思いますので、後日メンターさんに理由を聞いてみようと思います。