### PR TITLE
管理者側のユーザー編集機能実装

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,9 +9,22 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    if user = User.find_by(email: params[:user][:email])
+      if user.member_status == 1
+        redirect_to new_user_session_path
+        flash[:user_sign_in_failed] = "退会済みのアカウントです"
+      elsif user.member_status == 2
+        redirect_to new_user_session_path
+        flash[:user_sign_in_failed] = "このアカウントは管理者によって強制退会となったため、ご利用いただけません。"
+      else
+        super
+      end
+    else
+      redirect_to new_user_session_path
+      flash[:user_session_create_faled] = "入力内容を確認してください"
+    end
+  end
 
   # DELETE /resource/sign_out
   # def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,41 +1,89 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user_or_admin, except: [:index]
+  before_action :user_exists, except: [:index]
+  before_action :suspending_user_account
+  before_action :authenticate_current_user, except: [:index]
+
   def index
+    if admin_signed_in?
+      @users = User.all
+    else
+      redirect_to items_path
+    end
   end
 
   def edit
-    if User.exists?(params[:id])
-      @user = User.find(params[:id])
-      if @user.id != current_user.id
-        redirect_to user_path(current_user.id)
-      end
-    else
-      redirect_to user_path(current_user.id)
-    end
+  end
+
+  def edit_password
   end
 
   def show
-    if User.exists?(params[:id])
-      @user = User.find(params[:id])
-    else
-      redirect_to user_path(current_user.id)
-    end
+    @address = Address.where(user_id: params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
     if @user.update(user_params)
-      sign_in(@user, :bypass => true)
       redirect_to user_path(@user.id)
-      flash[:profile_updated] = "登録情報を保存しました"
+      flash[:user_updated] = "登録情報を保存しました"
     else
-      redirect_to user_path(current_user.id)
+      redirect_to user_path(@user.id)
+      flash[:user_update_faled] = "変更できませんでした。入力内容を確認してください。"
+    end
+  end
+=begin
+余裕あれば実装
+  def update_status
+    @user.update_attribute(:member_status, params[:user][:member_status])
+    redirect_to user_path(@user.id)
+    if @user.member_status == 0
+      flash[:user_restored] = "#{@user.family_name_kanji}#{@user.given_name_kanji}のユーザーステータスを【通常会員】に変更しました"
+    elsif @user.member_status == 1
+      flash[:user_deleted] = "#{@user.family_name_kanji}#{@user.given_name_kanji}のユーザーステータスを【退会】に変更しました"
+    elsif @user.member_status == 2
+      flash[:user_force_deleted] = "#{@user.family_name_kanji}#{@user.given_name_kanji}のユーザーステータスを【強制退会】に変更しました"
+    end
+  end
+=end
+  private
+
+  def authenticate_user_or_admin
+    if admin_signed_in? || user_signed_in?
+    else
+      redirect_to items_path
     end
   end
 
-  private
+  def user_exists
+    if User.exists?(params[:id])
+      @user = User.find(params[:id])
+    else
+      redirect_to items_path
+    end
+  end
+
+  def suspending_user_account
+    if user_signed_in?
+      if current_user.member_status == 1
+        redirect_to destroy_user_session_path(current_user)
+        flash[:deleted_user_account] = "退会済みのアカウントです。"
+      elsif current_user.member_status == 2
+        redirect_to destroy_user_session_path(current_user)
+        flash[:force_deleted_user_account] = "このアカウントは管理者によって強制退会となったため、ご利用いただけません。"
+      end
+    end
+  end
+
+  def authenticate_current_user
+    if user_signed_in?
+      if @user.id != current_user.id
+        redirect_to items_path
+      end
+    end
+  end
 
   def user_params
-    params.require(:user).permit(:cart_item_id, :order_id, :family_name_kanji, :given_name_kanji, :family_name_kana, :given_name_kana, :phone_number, :email, :password, :post_code, :address, :id)
+    params.require(:user).permit(:cart_item_id, :order_id, :family_name_kanji, :given_name_kanji, :family_name_kana, :given_name_kana, :phone_number, :email, :password, :post_code, :address, :member_status)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     }
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-  validates :email,               presence: true, uniqueness: true,
+  validates :email,             presence: true, uniqueness: true,
     format: { 
       with: VALID_EMAIL_REGEX, 
       message: "記入内容を確認して下さい。"
@@ -46,7 +46,8 @@ class User < ApplicationRecord
     length: {
       in: 6..20,
       message: "6〜20文字までのパスワードを入力してください"
-    }
+    },
+    on: :create
 
   validates :post_code,         presence: true,
     format: {
@@ -60,6 +61,25 @@ class User < ApplicationRecord
       with: /\A\d\z/, # 0 => 入会、1 => 退会済み、2 => 強制退会
       message: "半角数字で入力して下さい。"
     }
+
+  # Validation on update
+  validates :password,
+    length: { in: 6..20,
+              message: "6〜20文字までのパスワードを入力してください" },
+                                on: :update,
+                                allow_blank: true
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank?
+     params.delete(:password)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 
   # Association
   has_many :cart_items

--- a/app/views/users/_edit_admins.html.erb
+++ b/app/views/users/_edit_admins.html.erb
@@ -1,48 +1,94 @@
-<div class="container col-5" style="margin-top: 150px;">
-  <div class="jumbotron">
-    <h1 class="text-center font-weight-bold">登録情報変更</h1>
-    <label for="InputName">名前</label>
-    <div class="form-row">
-      <div class="form-group col-md-6">
-        <input type="name" class="form-control" id="InputName" placeholder="姓"></input>
+<div class="container-fluid">
+  <div class="row">
+
+    <!-- サイドバー -->
+    <%= render 'layouts/sidebar_admins', {} %> <!-- 変数を再定義する必要有り -->
+
+    <div class="col-10 py-4">
+      <div class="row justify-content-center">
+        <div class="col-6">
+
+          <div class="jumbotron">
+            <h1 class="text-center font-weight-bold">登録情報編集</h1>
+
+            <%= form_for(@user) do |f| %>
+
+              <label for="InputName">名前</label>
+              <div class="form-row">
+                <div class="form-group col-md-6">
+                  <%= f.text_field :family_name_kanji, autofocus: true, :placeholder=>"姓",  class:"form-control" %>
+                </div>
+                <div class="form-group col-md-6">
+                  <%= f.text_field :given_name_kanji, :placeholder=>"名", class:"form-control" %>
+                </div>
+              </div>
+              <label for="InputPassword">フリガナ(全角):</label>
+              <div class="form-row">
+                <div class="form-group col-md-6">
+                  <%= f.text_field :family_name_kana, :placeholder=>"セイ", class:"form-control" %>
+                </div>
+                <div class="form-group col-md-6">
+                  <%= f.text_field :given_name_kana, :placeholder=>"メイ", class:"form-control" %>
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="InputEmail">メールアドレス</label>
+                <%= f.email_field :email, autocomplete:"email", :placeholder=>"メールアドレスを入力して下さい", class:"form-control" %>
+              </div>
+              <div class="form-group">
+                <label for="InputAddress">郵便番号</label>
+                <%= f.text_field :post_code, :placeholder=>"ハイフンなし", class:"form-control" %>
+              </div>
+              <div class="form-group">
+                <label for="InputAddress">住所(全角)</label>
+                <%= f.text_field :address, :placeholder=>"住所", class:"form-control" %>
+              </div>
+              <div class="form-group">
+                <label for="InputTell">電話番号</label>
+                <%= f.text_field :phone_number, :placeholder=>"ハイフンなし", class:"form-control" %>
+              </div>
+              <div class="form-group">
+                <%if current_admin.is_main_administer == true && @admin != current_admin %>
+
+                  <div class="form-row">
+                    <div class="form-group col-12">
+                      <%= f.label :アカウントステータス %>
+                      <div>
+                        <label>
+                          <%= f.radio_button :member_status, 0, class: "mx-1" %>通常会員
+                        </label>
+
+                        <label>
+                          <%= f.radio_button :member_status, 1, class: "mx-1" %>退会
+                        </label>
+
+                        <label>
+                          <%= f.radio_button :member_status, 2, class: "mx-1" %>強制退会
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+
+                <% end %>
+              </div>
+<%
+=begin
+%>
+              <!-- 機能してません -->
+              <div class="form-group">
+                <label for="InputPassword">パスワード確認</label>
+                <%= f.password_field :password_confimation, autocomplete: "off", :placeholder=>"もう一度、パスワードを入力して下さい", class:"form-control" %>
+              </div>
+<%
+=end
+%>
+              <%= f.submit "-変更-", class:"btn btn-warning btn-block" %>
+
+            <% end %>
+
+          </div>
+        </div>
       </div>
-      <div class="form-group col-md-6">
-        <input type="name" class="form-control" id="InputName" placeholder="名"></input>
-      </div>
     </div>
-    <label for="InputPassword">フリガナ(全角):</label>
-    <div class="form-row">
-      <div class="form-group col-md-6">
-        <input type="name" class="form-control" id="InputName" placeholder="セイ"></input>
-      </div>
-      <div class="form-group col-md-6">
-        <input type="name" class="form-control" id="InputName" placeholder="メイ"></input>
-      </div>
-    </div>
-    <div class="form-group">
-      <label for="InputEmail">Emailアドレス</label>
-      <input class="form-control" id="InputEmail" placeholder="メールアドレスを入力して下さい"></input>
-    </div>
-    <div class="form-group">
-      <label for="InputAddress">郵便番号</label>
-      <input class="form-control" id="InputAddress" placeholder="ハイフンなし"></input>
-    </div>
-    <div class="form-group">
-      <label for="InputAddress">住所(全角)</label>
-      <input class="form-control" id="InputAddress" placeholder="住所"></input>
-    </div>
-    <div class="form-group">
-      <label for="InputTell">電話番号</label>
-      <input class="form-control" id="InputTell" placeholder="ハイフンなし"></input>
-    </div>
-    <div class="form-group">
-      <label for="InputPassword">Password</label>
-      <input class="form-control" id="InputPassword" placeholder="半角英数字(6文字~20文字)"></input>
-    </div>
-    <div class="form-group">
-      <label for="InputPassword">Password確認</label>
-      <input class="form-control" id="InputPassword" placeholder="もう一度、パスワードを入力して下さい"></input>
-    </div>
-    <button type="button" class="btn btn-warning btn-block">-変更を反映する-</button>
   </div>
 </div>

--- a/app/views/users/_show_admins.html.erb
+++ b/app/views/users/_show_admins.html.erb
@@ -1,73 +1,122 @@
 <div class="container-fluid" style="margin-top: 100px;">
   <div class="row">
+
+    <!-- サイドバー -->
+    <%= render 'layouts/sidebar_admins', {} %> <!-- 変数を再定義する必要有り -->
+
     <!-- メインページ -->
-    <div class="col-9">
-      <div class="row">
-        <div class="container">
-          <span class="font-weight-bold h2">User詳細</span>
-          <div class="box" style="height:10px;background-color:#005684;">
-          </div>
-          <p>The .table-striped class adds zebra-stripes to a table:</p>
-          <div class="card bg-light mb-3">
-            <table class="table table">
-              <thead style="background-color:#A8C6D7;">
-                <th>基本情報</th>
-                <th>ステータス: <a class="text-success border border-success">Menber</a></th>
-                <th>最終ログイン:2018/6/7</th>
-                <th><a class="btn btn-secondary btn-sm float-right" href="#" >注文履歴</a></th>
-                <th><a class="btn btn-secondary btn-sm float-right" href="#" >Edit</a></th>
-              </thead>
+    <div class="col-10 py-4">
 
-              <tbody>
-                <td>Name:</td>
-                <td>矢沢永吉</td>
-              </tbody>
-              <tbody>
-                <td>Email:</td>
-                <td>e.yazawa@example.com</td>
-              </tbody>
-              <tbody>
-                <td>郵便番号:</td>
-                <td>0000830</td>
-              </tbody>
-              <tbody>
-                <td>住所:</td>
-                <td>広島県広島市南区仁保830</td>
-              </tbody>
-              <tbody>
-                <td>TEL:</td>
-                <td>0900000830</td>
-              </tbody>
-              <tbody>
-                <td>Password:</td>
-                <td>******</td>
-              </tbody>
-              <tbody>
-              </tbody>
+      <span class="font-weight-bold h2">
+        <%= @user.family_name_kanji %>
+        <%= @user.given_name_kanji %>
+         の情報
+      </span>
+      <div class="box" style="height:10px;background-color:#005684;">
+      </div>
 
-            </table>
+      <p class="flash-message text-danger">
+        <%= flash[:user_update_faled] %>
+      </p>
 
-            <h1 class="badge badge-warning">送付先住所一覧</h1>
-            <table class="table table">
-              <thead style="background-color:#A8C6D7;">
-                <th>郵便番号</th>
-                <th>住所</th>
-                <th><a class="btn btn-success float-right btn-sm" href="#">送付先住所追加</a></th>
-              </thead>
-              <tbody>
-                <td>111111</td>
-                <td>東京都港区六本木830</td>
-                <td><a class="btn  btn-outline-danger btn-sm float-right">Delete</a></td>
-              </tbody>
-              <tbody>
-                <td>1234567</td>
-                <td>神奈川県横浜市830</td>
-                <td><a class="btn  btn-outline-danger btn-sm float-right">Delete</a></td>
-              </tbody>
-            </table>
+      <p class="flash-message text-primary">
+        <%= flash[:user_updated] %>
+      </p>
 
-          </div>
-        </div>
+      <p class="bg-warning rounded text-center mt-3">基本情報</p>
+
+      <div class="card bg-light my-3">
+
+        <table class="table table">
+          <thead style="background-color:#A8C6D7;">
+            <th>基本情報</th>
+            <th>ステータス: 
+              <% if @user.member_status == 0 %>
+                <span class="text-success border border-success">通常会員</span>
+              <% elsif @user.member_status == 1 %>
+                <span class="text-secondary border border-secondary">退会</span>
+              <% elsif @user.member_status == 2 %>
+                <span class="text-danger border border-danger">強制退会</span>
+              <% end %>
+            </th>
+            <th><%= @user.last_sign_in_at %></th>
+            <th>
+              <%= link_to "注文履歴", orders_path,class: "btn btn-secondary btn-sm float-right" %>
+            </th>
+            <th>
+              <%= link_to "編集", edit_user_path(@user),class: "btn btn-secondary btn-sm float-right" %>
+            </th>
+            <th>
+              <%= link_to "パスワード変更", user_edit_password_path(@user),class: "btn btn-secondary btn-sm float-right" %>
+            </th>
+          </thead>
+
+          <tbody>
+            <tr>
+              <th>名前:</th>
+              <td>
+                <%= @user.family_name_kanji %>
+                <%= @user.given_name_kanji %>
+              </td>
+            </tr>
+            <tr>
+              <th>メールアドレス:</th>
+              <td><%= @user.email %></td>
+            </tr>
+            <tr>
+              <th>郵便番号:</th>
+              <td><%= @user.post_code %></td>
+            </tr>
+            <tr>
+              <th>住所:</th>
+              <td><%= @user.address %></td>
+            </tr>
+            <tr>
+              <th>TEL:</th>
+              <td><%= @user.phone_number %></td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+      <p class="bg-warning rounded text-center">送付先住所一覧</p>
+
+      <div class="card bg-light my-3">
+
+        <% if Address.exists?(user_id: @user.id) %>
+
+          <table class="table table">
+            <thead style="background-color:#A8C6D7;">
+              <th>郵便番号</th>
+              <th>住所</th>
+              <th>
+                <%= link_to "送付先住所追加", new_address_path, class: "btn btn-success float-right btn-sm" %>
+              </th>
+            </thead>
+            <tbody>
+
+              <% @address.each do |address| %>
+
+                <tr>
+                  <td><%= address.post_code %></td>
+                  <td><%= address.address %></td>
+                  <td>
+                    <%= link_to "削除", address_path(address), method: :delete, "data-confirm" => "【 #{address.address} 】こちらの送付先住所を削除しますか？", class: "btn  btn-outline-danger btn-sm float-right" %>
+                  </td>
+                </tr>
+
+              <% end %>
+
+            </tbody>
+          </table>
+
+        <% else %>
+
+          <p class="text-center mt-3">送付先住所が登録されていません</p>
+
+        <% end %>
+
       </div>
     </div><!-- メインページの閉じタグ -->
   </div><!-- 全体rowの閉じタグ -->

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,44 +1,55 @@
-<div class="container py-4">
-  <div class="row justify-content-center">
-    <div class="col-5">
+<% if admin_signed_in? %>
 
-      <div class="jumbotron">
-    		<h1 class="text-center font-weight-bold">登録情報編集</h1>
-        <%= form_for(@user) do |f| %>
-          <%= f.label :名前 %>
-          <div class="form-inline">
-            <%= f.text_field :family_name_kanji, class:"form-control" %>
-            <%= f.text_field :given_name_kanji, class:"form-control" %>
-          </div>
-          <%= f.label :フリガナ全角 %>
-          <div class="form-inline">
-            <%= f.text_field :family_name_kana, class:"form-control" %>
-            <%= f.text_field :given_name_kana, class:"form-control" %>
-          </div>
-          <div class="form-group">
-            <%= f.label :Emailアドレス %>
-            <%= f.email_field :email, class:"form-control" %>
-          </div>
-          <div class="form-group">
-            <%= f.label :郵便番号 %>
-            <%= f.text_field :post_code, class:"form-control" %>
-          </div>
-          <div class="form-group">
-            <%= f.label :住所全角 %>
-            <%= f.text_field :address, class:"form-control" %>
-          <div class="form-group">
-            <%=  f.label :電話番号 %>
-            <%= f.text_field :phone_number, class:"form-control" %>
-          </div>
+  <%= render 'users/edit_admins' %>
 
-          <div class="form-group">
-            <%= f.label :Password %>
-            <%= f.password_field :password, class:"form-control", id:"InputPassword", placeholder:"半角英数字(6文字~20文字)" %>
-          </div>
+<% else %>
 
-          <%= f.submit "-情報を更新-", class:"btn btn-warning btn-block" %>
-        <% end %>
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-5">
+
+        <div class="jumbotron">
+      		<h1 class="text-center font-weight-bold">登録情報編集</h1>
+          <%= form_for(@user) do |f| %>
+            <%= f.label :名前 %>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <%= f.text_field :family_name_kanji, class:"form-control" %>
+                <%= f.text_field :given_name_kanji, class:"form-control" %>
+              </div>
+              <%= f.label :フリガナ全角 %>
+              <div class="form-group col-md-6">
+                <%= f.text_field :family_name_kana, class:"form-control" %>
+                <%= f.text_field :given_name_kana, class:"form-control" %>
+              </div>
+            </div>
+            <div class="form-group">
+              <%= f.label :Emailアドレス %>
+              <%= f.email_field :email, class:"form-control" %>
+            </div>
+            <div class="form-group">
+              <%= f.label :郵便番号 %>
+              <%= f.text_field :post_code, class:"form-control" %>
+            </div>
+            <div class="form-group">
+              <%= f.label :住所全角 %>
+              <%= f.text_field :address, class:"form-control" %>
+            <div class="form-group">
+              <%=  f.label :電話番号 %>
+              <%= f.text_field :phone_number, class:"form-control" %>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :Password %>
+              <%= f.password_field :password, class:"form-control", id:"InputPassword", placeholder:"半角英数字(6文字~20文字)" %>
+            </div>
+
+            <%= f.submit "-情報を更新-", class:"btn btn-warning btn-block" %>
+          <% end %>
+        </div>
+
       </div>
-
     </div>
   </div>
+
+<% end %>

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,53 @@
+<!-- ユーザーのパスワード変更画面 -->
+
+<div class="container-fluid">
+  <div class="row">
+
+    <% if admin_signed_in? %>
+
+      <!-- サイドバー -->
+      <%= render 'layouts/sidebar_admins', {} %> <!-- 変数を再定義する必要有り -->
+
+    <% end %>
+
+    <!-- メインページ -->
+    <div class="col-10 my-4">
+      <div class="row justify-content-center">
+        <div class="col-6 jumbotron">
+          <p class="text-center h5">
+            <%= @user.family_name_kanji %><%= @user.given_name_kanji %>
+          </p>
+          <h1 class="text-center font-weight-bold">パスワード変更</h1>
+          <%= form_for(@user) do |f| %>
+            <!-- パスワード -->
+            <%= f.label :新しいパスワード %>
+            <div class="form-row">
+              <div class="form-group col-12">
+                <%= f.password_field :password, class:"form-control", id:"InputPassword", placeholder:"半角英数字(6文字~20文字)" %>
+              </div>
+            </div>
+<%
+=begin
+%>
+            <!-- 現状機能していない -->
+            <!-- パスワード再入力 -->
+            <%= f.label :パスワード確認 %>
+            <div class="form-row">
+              <div class="form-group col-12">
+                <%= f.password_field :password_confirmation, class:"form-control", id:"InputPassword", placeholder:"もう一度、パスワードを入力して下さい" %>
+              </div>
+            </div>
+<%
+=end
+%>
+            <!-- 登録ボタン -->
+            <%= f.submit "-パスワードを変更-", class:"btn btn-warning btn-block" %>
+
+          <% end %>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,84 +5,74 @@
     <%= render 'layouts/sidebar_admins', {} %> <!-- 変数を再定義する必要有り -->
 
     <!-- メインページ -->
-    <div class="col-9 py-4">
-      <div class="row">
-        <div class="container">
-          <span class="font-weight-bold h2">User一覧</span>
-          <div class="box" style="height:10px;background-color:#005684;"></div>
-	          <p>The .table-striped class adds zebra-stripes to a table:</p>
-	          <table class="table table-striped">
-	            <thead>
-	              <tr>
-	                <th>Name</th>
-	                <th>Email</th>
-	                <th>購入回数</th>
-	                <th>最終ログイン</th>
-	                <th>Status</th>
-	                <th></th>
-	              </tr>
-	            </thead>
-	            <tbody>
-	              <tr>
-	                <td>矢沢永吉</td>
-	                <td>e.yazawa@example.com</td>
-	                <td>28</td>
-	                <td>2018/6/7</td>
-	                <td>Member</td>
-	                <td><button type="button" class="btn btn-success">Show</button></td>
-	              </tr>
-	              <tr>
-	                <td>成田三樹夫</td>
-	                <td>n.mikki@example.com</td>
-	                <td>34</td>
-	                <td>2018/2/6</td>
-	                <td>Unsubscribe</td>
-	                <td><button type="button" class="btn btn-success">Show</button></td>
-	              </tr>
-	              <tr>
-	                <td>菅原文太</td>
-	                <td>bun@example.com</td>
-	                <td>9</td>
-	                <td>2018/1/23</td>
-	                <td>Delete</td>
-	                <td><button type="button" class="btn btn-success">Show</button></td>
-	              </tr>
-	              <tr>
-	                <td>田岡一雄</td>
-	                <td>yamaguchi@example.com</td>
-	                <td>56</td>
-	                <td>2018/6/5</td>
-	                <td>Menber</td>
-	                <td><button type="button" class="btn btn-success">Show</button></td>
-	              </tr>
-	              <tr>
-	                <td>菅谷政雄</td>
-	                <td>bonno@example.com</td>
-	                <td>13</td>
-	                <td>2018/5/4</td>
-	                <td>Menber</td>
-	                <td><button type="button" class="btn btn-success">Show</button></td>
-	              </tr>
-	            </tbody>
-	          </table>
-      		</div>
-     		</div>
+    <div class="col-10 py-4">
 
-	      <div class="row"><!-- ページネーション -->
-	        <div class="col-12">
-	          <nav aria-label="Page navigation example">
-	            <ul class="pagination justify-content-center">
-	              <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-	              <li class="page-item"><a class="page-link" href="#">1</a></li>
-	              <li class="page-item"><a class="page-link" href="#">2</a></li>
-	              <li class="page-item"><a class="page-link" href="#">3</a></li>
-	              <li class="page-item"><a class="page-link" href="#">Next</a></li>
-	            </ul>
-	          </nav>
-	        </div>
-	      </div><!-- ページネーション閉じタグ -->
+      <span class="font-weight-bold h2">User一覧</span>
+      <div class="box" style="height:10px;background-color:#005684;"></div>
 
-      </div><!-- メインページrowの閉じタグ -->
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>名前</th>
+              <th>メールアドレス</th>
+              <th>購入回数</th>
+              <th>最終ログイン</th>
+              <th>会員ステータス</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+
+          	<% @users.each do |user| %>
+
+              <tr>
+                <td>
+                	<%= user.family_name_kanji %>
+                	<%= user.given_name_kanji %>
+              	</td>
+                <td>
+                	<%= user.email %>
+               	</td>
+                <td>
+
+              	</td>
+                <td>
+                	<%= user.last_sign_in_at %>
+              	</td>
+                <td>
+                	<% if user.member_status == 0 %>
+                		<span>通常会員</span>
+                	<% elsif user.member_status == 1 %>
+                		<span>退会</span>
+                	<% elsif user.member_status == 2 %>
+                		<span>強制退会</span>
+                	<% end %>
+                </td>
+                <td>
+                	<%= link_to "詳細", user_path(user),class: "btn btn-success btn-sm" %>
+                </td>
+              </tr>
+
+            <% end %>
+
+          </tbody>
+        </table>
+  		</div>
+
+      <div class="row"><!-- ページネーション -->
+        <div class="col-12">
+          <nav aria-label="Page navigation example">
+            <ul class="pagination justify-content-center">
+              <!--<li class="page-item"><a class="page-link" href="#">Previous</a></li>
+              <li class="page-item"><a class="page-link" href="#">1</a></li>
+              <li class="page-item"><a class="page-link" href="#">2</a></li>
+              <li class="page-item"><a class="page-link" href="#">3</a></li>
+              <li class="page-item"><a class="page-link" href="#">Next</a></li>-->
+            </ul>
+          </nav>
+        </div>
+      </div><!-- ページネーション閉じタグ -->
+
     </div><!-- メインページcol-9の閉じタグ -->
   </div><!-- 全体rowの閉じタグ -->
 </div><!-- 全体containerの閉じタグ -->

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,54 +4,54 @@
 
       <div class="jumbotron">
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= devise_error_messages! %>
-        <h1 class="text-center font-weight-bold">新規登録</h1>
-        <label for="InputName">名前</label>
-        <div class="form-row">
-          <div class="form-group col-md-6">
-            <%= f.text_field :family_name_kanji, autofocus: true, :placeholder=>"姓",  class:"form-control" %>
+          <%= devise_error_messages! %>
+          <h1 class="text-center font-weight-bold">新規登録</h1>
+          <label for="InputName">名前</label>
+          <div class="form-row">
+            <div class="form-group col-md-6">
+              <%= f.text_field :family_name_kanji, autofocus: true, :placeholder=>"姓",  class:"form-control" %>
+            </div>
+            <div class="form-group col-md-6">
+              <%= f.text_field :given_name_kanji, :placeholder=>"名", class:"form-control" %>
+            </div>
           </div>
-          <div class="form-group col-md-6">
-            <%= f.text_field :given_name_kanji, :placeholder=>"名", class:"form-control" %>
+          <label for="InputPassword">フリガナ(全角):</label>
+          <div class="form-row">
+            <div class="form-group col-md-6">
+              <%= f.text_field :family_name_kana, :placeholder=>"セイ", class:"form-control" %>
+            </div>
+            <div class="form-group col-md-6">
+              <%= f.text_field :given_name_kana, :placeholder=>"メイ", class:"form-control" %>
+            </div>
           </div>
-        </div>
-        <label for="InputPassword">フリガナ(全角):</label>
-        <div class="form-row">
-          <div class="form-group col-md-6">
-            <%= f.text_field :family_name_kana, :placeholder=>"セイ", class:"form-control" %>
+          <div class="form-group">
+            <label for="InputEmail">メールアドレス</label>
+            <%= f.email_field :email, autocomplete:"email", :placeholder=>"メールアドレスを入力して下さい", class:"form-control" %>
           </div>
-          <div class="form-group col-md-6">
-            <%= f.text_field :given_name_kana, :placeholder=>"メイ", class:"form-control" %>
+          <div class="form-group">
+            <label for="InputAddress">郵便番号</label>
+            <%= f.text_field :post_code, :placeholder=>"ハイフンなし", class:"form-control" %>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="InputEmail">Emailアドレス</label>
-          <%= f.email_field :email, autocomplete:"email", :placeholder=>"メールアドレスを入力して下さい", class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <label for="InputAddress">郵便番号</label>
-          <%= f.text_field :post_code, :placeholder=>"ハイフンなし", class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <label for="InputAddress">住所(全角)</label>
-          <%= f.text_field :address, :placeholder=>"住所", class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <label for="InputTell">電話番号</label>
-          <%= f.text_field :phone_number, :placeholder=>"ハイフンなし", class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <label for="InputPassword">Password</label>
-          <%= f.password_field :password, autocomplete: "off", :placeholder=>"半角英数字(6文字~20文字)",  class:"form-control" %>
-        </div>
-        <div class="form-group">
-          <label for="InputPassword">Password確認</label>
-          <%= f.password_field :password_confimation, autocomplete: "off", :placeholder=>"もう一度、パスワードを入力して下さい", class:"form-control" %>
-        </div>
-        <%= f.submit "-東西アカウントを作成-", class:"btn btn-warning btn-block" %>
+          <div class="form-group">
+            <label for="InputAddress">住所(全角)</label>
+            <%= f.text_field :address, :placeholder=>"住所", class:"form-control" %>
+          </div>
+          <div class="form-group">
+            <label for="InputTell">電話番号</label>
+            <%= f.text_field :phone_number, :placeholder=>"ハイフンなし", class:"form-control" %>
+          </div>
+          <div class="form-group">
+            <label for="InputPassword">パスワード</label>
+            <%= f.password_field :password, autocomplete: "off", :placeholder=>"半角英数字(6文字~20文字)",  class:"form-control" %>
+          </div>
+          <div class="form-group">
+            <label for="InputPassword">パスワード確認</label>
+            <%= f.password_field :password_confimation, autocomplete: "off", :placeholder=>"もう一度、パスワードを入力して下さい", class:"form-control" %>
+          </div>
+          <%= f.submit "-東西アカウントを作成-", class:"btn btn-warning btn-block" %>
         <% end %>
+
       </div>
     </div>
-
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,12 @@
 <div class="container py-4">
+
+  <p class="flash-message text-danger text-center">
+    <%= flash[:user_sign_in_failed] %>
+    <%= flash[:user_session_create_faled] %>
+  </p>
+
   <div class="row justify-content-center">
+
     <div class="col-5">
 
       <div class="jumbotron">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
     resources :cart_items, only: [:index, :destroy, :all_destroy, :create, :update]
   end
 
+  get '/users/:id/edit_password' => 'users#edit_password', as: 'user_edit_password'
+  #post '/users/:id' => 'users#update_status', as: 'update_status_user'
+
   delete '/users/:id/cart_items' => 'cart_items#all_destroy', as: 'all_destroy_cart_items'
 
   resources :addresses, except: [:index, :show]

--- a/db/fixtures/development/address.rb
+++ b/db/fixtures/development/address.rb
@@ -1,0 +1,31 @@
+Address.seed do |s|
+  s.id = 1
+  s.user_id = 1
+  s.name = "東西"
+  s.post_code = "1234567"
+  s.address = "長崎県"
+end
+
+Address.seed do |s|
+  s.id = 2
+  s.user_id = 3
+  s.name = "太郎"
+  s.post_code = "1234567"
+  s.address = "鹿児島"
+end
+
+Address.seed do |s|
+  s.id = 3
+  s.user_id = 3
+  s.name = "二郎"
+  s.post_code = "1234567"
+  s.address = "北海道"
+end
+
+Address.seed do |s|
+  s.id = 4
+  s.user_id = 4
+  s.name = "本社"
+  s.post_code = "1234567"
+  s.address = "東京都"
+end


### PR DESCRIPTION
管理者側からユーザーの会員ステータスやパスワードを含む基本情報の編集ができます。
会員ステータスが1か2の会員はログインできないようにしてあります。
ユーザー側からの登録や編集機能はコントローラーが被っているのでほぼ出来あがっていますが、別ブランチでやります。